### PR TITLE
[TASK] make the filter of extension list search for any matches of string

### DIFF
--- a/Resources/Public/JavaScript/Translation/snowbabel_extensionmenu.js
+++ b/Resources/Public/JavaScript/Translation/snowbabel_extensionmenu.js
@@ -138,7 +138,7 @@ TYPO3.Snowbabel.ExtensionMenu = Ext.extend(Ext.Panel , {
 		var ExtensionFilter = Ext.getCmp('ExtensionFilter');
 		var View = Ext.getCmp('snowbabel-extension-menu-view');
 
-		View.store.filter('ExtensionTitle', ExtensionFilter.getValue());
+		View.store.filter('ExtensionTitle', ExtensionFilter.getValue(), true);
 	}
 
 });


### PR DESCRIPTION
In the translate module you can filter the list of extension trough an input field. As of now only matches at the beginning of the extension names are found. This patch changes this behaviour to match every occurrence of the searched string to have a more convinient search result.
