### PR TITLE
[BUGFIX] Check if  is an Object before calling methods

### DIFF
--- a/Classes/Service/Translations.php
+++ b/Classes/Service/Translations.php
@@ -1188,6 +1188,10 @@ class Translations {
 		/** @var \SimpleXMLElement $bodyOfFileTag */
 		$bodyOfFileTag = $simpleXmlObject->file->body;
 
+		if (!is_object($bodyOfFileTag)) {
+			return $parsedData;
+		}
+
 		foreach ($bodyOfFileTag->children() as $translationElement) {
 
 			$elementName = $translationElement->getName();


### PR DESCRIPTION
Fix for the following Exception:

Fatal error: Call to a member function children() on a non-object in ./ext/snowbabel/Classes/Service/Translations.php on line 1187

Is thrown if you have a xliff file with a body element without child elements.
