### PR TITLE
index also files with multiple dots in filename

### DIFF
--- a/Classes/Service/Translations.php
+++ b/Classes/Service/Translations.php
@@ -1099,23 +1099,16 @@ class Translations {
 	private function getFileInfos($file) {
 
 		$fileInfo = array ();
+		$fileArray = pathinfo($file);
 
-		// Explode Array By Points -> FileExtension Should Be Last
-		$fileArray = explode('.', $file);
-
-		// Reverse Array
-		// -> FileExtension Is Now First Element
-		// -> FileBasename Is Now Second Part
-		$fileArray = array_reverse($fileArray);
-
-		$fileInfo['Extension'] = $fileArray[0];
-		$fileInfo['Filename'] = $fileArray[1];
+		$fileInfo['Extension'] = $fileArray['extension'];
+		$fileInfo['Filename'] = $fileArray['dirname'] .'/'. $fileArray['filename'];
 
 		// Add Basename
-		$fileInfo['Basename'] = pathinfo($file, PATHINFO_BASENAME);
+		$fileInfo['Basename'] = $fileArray['basename'];
 
 		// Add Dirname
-		$fileInfo['Dirname'] = pathinfo($file, PATHINFO_DIRNAME) . '/';
+		$fileInfo['Dirname'] = $fileArray['dirname'] . '/';
 
 		return $fileInfo;
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,10 @@
 {
-    "name": "Snowflake/Snowbabel",
+    "name": "aoe/snowbabel",
     "description": "Translation Extension",
     "type": "typo3-cms-extension",
-    "version": "4.3.0"
+    "version": "4.3.0",
+    "require": {
+        "typo3/cms-core": ">=7.6,<9.0",
+        "typo3-ter/static-info-tables": "*"
+    }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = array (
 		'depends' => array (
 			'php' => '5.4-0.0.0',
 			'typo3' => '6.2.0-6.2.99',
-			'static_info_tables' => '6.1.0-6.1.99',
+			'static_info_tables' => '6.1.0-6.4.99',
 		),
 		'conflicts' => array (),
 		'suggests' => array (),

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -21,7 +21,7 @@ CREATE TABLE tx_snowbabel_users (
 	crdate int(11) DEFAULT '0' NOT NULL,
 	deleted tinyint(4) DEFAULT '0' NOT NULL,
 	be_users_uid int(11) DEFAULT '0' NOT NULL,
-	SelectedLanguages tinytext NOT NULL,
+	SelectedLanguages tinytext NOT NULL DEFAULT '0',
 	ShowColumnLabel tinyint(4) DEFAULT '1' NOT NULL,
 	ShowColumnDefault tinyint(4) DEFAULT '1' NOT NULL,
 


### PR DESCRIPTION
Allow multiple dots in filename. If u have for example a file like "locallang.formhandler.contact.xml" u will get as result contact as filename but it should be formhandler.contact.
