### PR TITLE
Update Translations.php

### DIFF
--- a/Classes/Service/Translations.php
+++ b/Classes/Service/Translations.php
@@ -707,6 +707,7 @@ class Translations
             $OriginalTranslationPath = $FileInfo['Dirname'] . $LanguageKey . '.' . $FileInfo['Basename'];
 
             // Get Path To l10n Location
+            // llXmlAutoFileName is deprecated (error on start of Scheduler task, TYPO3 9.5), AbstractXmlParser should be used.
             $TranslationFileName = GeneralUtility::llXmlAutoFileName($FilePath, $LanguageKey);
             $TranslationFilePath = GeneralUtility::getFileAbsFileName($TranslationFileName);
 


### PR DESCRIPTION
llXmlAutoFileName is deprecated (error on start of Scheduler task, TYPO3 9.5), AbstractXmlParser should be used.